### PR TITLE
Update display-contributors.html

### DIFF
--- a/themes/sixtyth-fortran/layouts/partials/display-contributors.html
+++ b/themes/sixtyth-fortran/layouts/partials/display-contributors.html
@@ -14,7 +14,7 @@
           {{- end -}}
         {{- end -}}
       {{- else -}}
-        <strong>NOOOOBODY!!!!!</strong>
+        <strong>Nobody has contributed to this article yet.</strong> Use the "Contribute" button above to make the first edit!
       {{- end -}}
       {{ with .GitInfo }}
         <strong> | Last updated on: </strong>{{ .AuthorDate.Format "Jan. 2, 2006" }}


### PR DESCRIPTION
A more professional message for when there are no contributors, understanding we need empty pages so that people can still search for things, since we no longer have redlinks.