### PR TITLE
changed the rae control system character connector line to amphenol

### DIFF
--- a/content/wiki/rock-afire-explosion-control-system.html
+++ b/content/wiki/rock-afire-explosion-control-system.html
@@ -7,7 +7,7 @@ categories = ["ShowBiz Pizza Place"]
 
 startDate = ""
 endDate = ""
-contributors = ["BattleXGamer","The 64th Gamer"]
+contributors = ["BattleXGamer","The 64th Gamer","ChloeThePuppyGirl"]
 citations = []
 +++
 
@@ -15,7 +15,7 @@ citations = []
 The Grey Box is a animatronic controller which contained parts from the Pianocorder with some modification from Creative Engineering. It as suggested uses {{< wiki-link "Pianocorder Data Format" >}} as a input to then control a Rock Afire Explosion.
 <h3> I/O </h3>
 2x Data input (RCA Jack I presume)
-Character output connector (Centronics Connector)
+Character output connector (Amphenol Connector)
 <h3> Hardware Breakdown </h3>
 6x Pianocorder Driver Boards
 2x Pianocorder Playback Boards


### PR DESCRIPTION
the official rae handbook on internet archive (handbook originally made by aaron/cei) says those connectors are officially called amphenol, centronics is the 80s computer to printer communication protocol